### PR TITLE
[CI] Update lint CI action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,15 +4,15 @@ on: [pull_request]
 
 jobs:
   clang-format:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       BASE_REF: ${{ github.base_ref }}
     steps:
       - name: Installing dependencies
         run: |
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends clang-format-9
-          wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends clang-format-14
+          wget https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/git-clang-format -O /tmp/git-clang-format
           chmod +x /tmp/git-clang-format
       - name: Checking out repository
         uses: actions/checkout@v2
@@ -21,5 +21,5 @@ jobs:
         run: git fetch --no-tags --prune --depth=1 origin "${BASE_REF?}:${BASE_REF?}"
       - name: Running clang-format on changed source files
         run: |
-          /tmp/git-clang-format "${BASE_REF?}" --binary=clang-format-9 --style=file
+          /tmp/git-clang-format "${BASE_REF?}" --binary=clang-format-14 --style=file
           git diff --exit-code


### PR DESCRIPTION
- Update the Ubuntu used by the runner to 22.04 -- 18.04 is deprecated: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/.

- Update clang-format from 9 to 14. This version is available in Ubuntu 22+ and Android SDK r29+.