### PR TITLE
Add i32 matmul benchmark variant

### DIFF
--- a/benchmarks/matmul/CMakeLists.txt
+++ b/benchmarks/matmul/CMakeLists.txt
@@ -45,6 +45,19 @@ uvkc_glsl_shader_permutation(
 
 uvkc_glsl_shader_permutation(
   NAME
+    matmul_tiled_shader_i32_adreno
+  SRC
+    "matmul_tiled_i32.glsl"
+  PERMUTATION
+    "TILE_M=[2|4|8|16|32]"
+    "TILE_N=[128|256]"
+    "TILE_K=[4|8]"
+    "WG_X=32"
+    "WG_Y=2"
+)
+
+uvkc_glsl_shader_permutation(
+  NAME
     matmul_tiled_shader_i8_adreno
   SRC
     "matmul_tiled_i8.glsl"
@@ -64,6 +77,7 @@ uvkc_cc_binary(
   DEPS
     ::matmul_tiled_shader_f16_adreno
     ::matmul_tiled_shader_f32_adreno
+    ::matmul_tiled_shader_i32_adreno
     ::matmul_tiled_shader_i8_adreno
     benchmark::benchmark
     uvkc::benchmark::core
@@ -105,6 +119,19 @@ uvkc_glsl_shader_permutation(
 
 uvkc_glsl_shader_permutation(
   NAME
+    matmul_tiled_shader_i32_valhall
+  SRC
+    "matmul_tiled_i32.glsl"
+  PERMUTATION
+    "TILE_M=[2|4|8|16|32]"
+    "TILE_N=[64|128]"
+    "TILE_K=[4|8]"
+    "WG_X=16"
+    "WG_Y=1"
+)
+
+uvkc_glsl_shader_permutation(
+  NAME
     matmul_tiled_shader_i8_valhall
   SRC
     "matmul_tiled_i8.glsl"
@@ -124,6 +151,7 @@ uvkc_cc_binary(
   DEPS
     ::matmul_tiled_shader_f16_valhall
     ::matmul_tiled_shader_f32_valhall
+    ::matmul_tiled_shader_i32_valhall
     ::matmul_tiled_shader_i8_valhall
     benchmark::benchmark
     uvkc::benchmark::core

--- a/benchmarks/matmul/matmul_tiled_i32.glsl
+++ b/benchmarks/matmul/matmul_tiled_i32.glsl
@@ -18,11 +18,10 @@
 #extension GL_EXT_scalar_block_layout : enable
 #extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_explicit_arithmetic_types : enable
-#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int32 : require
 
-layout(binding = 0) buffer InputA { i8vec4 x[]; } inputA;
-layout(binding = 1) buffer InputB { i8vec4 x[]; } inputB;
+layout(binding = 0) buffer InputA { i32vec4 x[]; } inputA;
+layout(binding = 1) buffer InputB { i32vec4 x[]; } inputB;
 layout(binding = 2) buffer Output { i32vec4 x[]; } outputO;
 
 layout(local_size_x = WG_X, local_size_y = WG_Y, local_size_z = 1) in;
@@ -44,7 +43,7 @@ void main() {
   uvec2 gID = gl_WorkGroupID.xy;
   uvec2 laneId = gl_LocalInvocationID.xy;
   i32vec4 C[C_ROWS][C_COLS];
-  i8vec4 B[TILE_K][C_COLS];
+  i32vec4 B[TILE_K][C_COLS];
 
   // Initialize result to zero
   [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
@@ -66,13 +65,12 @@ void main() {
       uint gi = gID.y * TILE_M + laneId.y + i * WG_Y;
       uint gk = k / 4;
       [[unroll]] for (uint kk = 0; kk < TILE_K / 4; ++kk) {
-        i8vec4 A = inputA.x[coordToOffset(gi, gk + kk, strideA / 4)];
+        i32vec4 A = inputA.x[coordToOffset(gi, gk + kk, strideA / 4)];
         [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
-          vec4 acc = vec4(A.x, A.x, A.x, A.x) * vec4(B[0 + 4 * kk][j]);
-          acc += vec4(A.y, A.y, A.y, A.y) * vec4(B[1 + 4 * kk][j]);
-          acc += vec4(A.z, A.z, A.z, A.z) * vec4(B[2 + 4 * kk][j]);
-          acc += vec4(A.w, A.w, A.w, A.w) * vec4(B[3 + 4 * kk][j]);
-          C[i][j] += i32vec4(acc.x, acc.y, acc.z, acc.w);
+          C[i][j] += i32vec4(A.x, A.x, A.x, A.x) * (B[0 + 4 * kk][j]);
+          C[i][j] += i32vec4(A.y, A.y, A.y, A.y) * (B[1 + 4 * kk][j]);
+          C[i][j] += i32vec4(A.z, A.z, A.z, A.z) * (B[2 + 4 * kk][j]);
+          C[i][j] += i32vec4(A.w, A.w, A.w, A.w) * (B[3 + 4 * kk][j]);
         }
       }
     }


### PR DESCRIPTION
Also use f32 fma in i8->i32 matmul implementation. This increases GFLOps from ~230 to ~330.