### PR TITLE
[matmul] Tweak innerproduct i8->i32 implementation

### DIFF
--- a/benchmarks/matmul/matmul_tiled_i8_innerproduct.glsl
+++ b/benchmarks/matmul/matmul_tiled_i8_innerproduct.glsl
@@ -36,7 +36,7 @@ const uint strideB = N;
 const uint strideC = N;
 
 const uint C_ROWS = TILE_M / WG_Y;
-const uint C_COLS = TILE_N / (1 * WG_X);
+const uint C_COLS = TILE_N / WG_X;
 
 uint coordToOffset(uint i, uint j, uint stride) { return (stride * i + j); }
 
@@ -44,7 +44,7 @@ void main() {
   uvec2 gID = gl_WorkGroupID.xy;
   uvec2 laneId = gl_LocalInvocationID.xy;
   int32_t C[C_ROWS][C_COLS]; // Local data for the output.
-  i8vec4 B[C_COLS][TILE_K / 4]; // Prefetched data for RHS.
+  i8vec4 B[TILE_K / 4][C_COLS]; // Prefetched data for RHS.
 
   // Initialize result to zero.
   [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
@@ -57,30 +57,32 @@ void main() {
   for (uint k_pos = 0; k_pos < K; k_pos += TILE_K) {
     // Prefetch RHS.
     [[unroll]] for (uint k = 0; k < TILE_K; k += 4) {
-      uint x = gID.x * TILE_N + laneId.x;
-      [[unroll]] for (uint j = 0; j < C_COLS; ++j, x += WG_X) {
-        uint gk = k + k_pos;
-        B[j][k / 4] = i8vec4(inputB.x[coordToOffset(gk + 0, x, strideB)],
-                             inputB.x[coordToOffset(gk + 1, x, strideB)],
-                             inputB.x[coordToOffset(gk + 2, x, strideB)],
-                             inputB.x[coordToOffset(gk + 3, x, strideB)]);
+      uint gk = k + k_pos;
+      [[unroll]] for (uint j = 0; j < C_COLS; j += 4) {
+        uint x = gID.x * TILE_N + j * WG_X + laneId.x;
+        [[unroll]] for (uint jj = 0; jj < 4; ++jj) {
+          B[k / 4][j + jj].x = inputB.x[coordToOffset(gk + 0, x + jj * WG_X, strideB)];
+          B[k / 4][j + jj].y = inputB.x[coordToOffset(gk + 1, x + jj * WG_X, strideB)];
+          B[k / 4][j + jj].z = inputB.x[coordToOffset(gk + 2, x + jj * WG_X, strideB)];
+          B[k / 4][j + jj].w = inputB.x[coordToOffset(gk + 3, x + jj * WG_X, strideB)];
+        }
       }
     }
 
     [[unroll]] for (uint i = 0; i < C_ROWS; ++i) {
-      uint y = gID.y * TILE_M + i * WG_Y + laneId.y;
-      [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
-        uint x = gID.x * TILE_N + j * WG_X + laneId.x;
-        int32_t acc = 0;
-        [[unroll]] for (uint k = 0; k < TILE_K; k += 4) {
-          uint gk = k + k_pos;
-          i32vec4 lhs = inputA.x[coordToOffset(y, gk, strideA) / 4];
-          i8vec4 b = B[j][k / 4];
-          i32vec4 rhs = i32vec4(b.x, b.y, b.z, b.w);
-          i32vec4 mul = lhs * rhs;
-          acc += mul.x + mul.y + mul.z + mul.w;
+      [[unroll]] for (uint k = 0; k < TILE_K; k += 4) {
+        uint y = gID.y * TILE_M + i * WG_Y + laneId.y;
+        uint gk = k + k_pos;
+        i16vec4 lhs = inputA.x[coordToOffset(y, gk, strideA) / 4];
+        [[unroll]] for (uint j = 0; j < C_COLS; ++j) {
+          uint x = gID.x * TILE_N + j * WG_X + laneId.x;
+
+          int32_t acc = 0;
+          i16vec4 rhs = B[k / 4][j];
+          i16vec4 mul = lhs * rhs;
+          acc += int32_t(mul.x) + int32_t(mul.y) + int32_t(mul.z) + int32_t(mul.w);
+          C[i][j] += acc;
         }
-        C[i][j] += acc;
       }
     }
   }


### PR DESCRIPTION
Perform intermediate computation (multiplication) on i16 operands to allow to improve register usage.

This improves performance from ~190 to ~245 GFLOps on Pixel 6.