### PR TITLE
Fix subgroup_arithmetic benchmark for flexible subgroup sizes

### DIFF
--- a/benchmarks/subgroup/subgroup_arithmetic_intrinsic.glsl
+++ b/benchmarks/subgroup/subgroup_arithmetic_intrinsic.glsl
@@ -16,6 +16,7 @@
 
 #extension GL_KHR_shader_subgroup_basic : enable
 #extension GL_KHR_shader_subgroup_arithmetic : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
 
 layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
@@ -28,12 +29,13 @@ layout(set = 0, binding = 0) buffer InputBuffer {
 // Use an output buffer of the same size to make sure we use each element
 // in the input buffer.
 layout(set = 0, binding = 1) buffer OutputBuffer {
+    uint actual_subgroup_size;
     float output_values[kArraySize];
 };
 
 void main() {
     uint index = gl_GlobalInvocationID.x;
-    uint count = gl_SubgroupSize;
+    uint subgroup_size = subgroupBallotBitCount(subgroupBallot(true));
     float value = 0.f;
 
 #ifdef ARITHMETIC_ADD
@@ -48,6 +50,7 @@ void main() {
       value = input_values[index];
     }
 
+    actual_subgroup_size = subgroup_size;
     output_values[index] = value;
 }
 

--- a/benchmarks/subgroup/subgroup_arithmetic_loop.glsl
+++ b/benchmarks/subgroup/subgroup_arithmetic_loop.glsl
@@ -15,6 +15,7 @@
 #version 450 core
 
 #extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_ballot : enable
 
 layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
@@ -27,12 +28,14 @@ layout(set = 0, binding = 0) buffer InputBuffer {
 // Use an output buffer of the same size to make sure we use each element
 // in the input buffer.
 layout(set = 0, binding = 1) buffer OutputBuffer {
+    uint actual_subgroup_size;
     float output_values[kArraySize];
 };
 
 void main() {
     uint index = gl_GlobalInvocationID.x;
-    uint count = gl_SubgroupSize;
+    uint subgroup_size = subgroupBallotBitCount(subgroupBallot(true));
+    uint count = subgroup_size;
     float value = 0.f;
 
     if (subgroupElect()) {
@@ -50,5 +53,6 @@ void main() {
       value = input_values[index];
     }
 
+    actual_subgroup_size = subgroup_size;
     output_values[index] = value;
 }


### PR DESCRIPTION
Set up source data values according to the subgroupSize device property. But inside the shader, measure the actual subgroup size, and pass it out of the shader. Then, adjust the verification logic to take that actual subgroup size into account.

This still does the same amount of arithmetic as in the original code, and it does it in the same shape.

Fixes: #45