### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/build-android-linux.yml
+++ b/.github/workflows/build-android-linux.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   linux_debug_build:
     name: Linux Debug Build
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     container:
       image: antiagainst/uvkcompute-ci:latest
     steps:
@@ -21,7 +21,7 @@ jobs:
         run: ./tools/ci/build_linux.sh Debug
   linux_release_build:
     name: Linux Release Build
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     container:
       image: antiagainst/uvkcompute-ci:latest
     steps:
@@ -31,7 +31,7 @@ jobs:
         run: ./tools/ci/build_linux.sh Release
   android_release_build:
     name: Android Release Build
-    runs-on: ubuntu-20.04
+    runs-on: 'ubuntu-24.04'
     container:
       image: antiagainst/uvkcompute-ci:latest
     steps:


### PR DESCRIPTION
This is a LSC run by http://go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
