### PR TITLE
Add missing glslc argument "--target-env=vulkan1.1"

### DIFF
--- a/benchmarks/compute/CMakeLists.txt
+++ b/benchmarks/compute/CMakeLists.txt
@@ -19,6 +19,8 @@ uvkc_glsl_shader_permutation(
     "mad_throughput.glsl"
   PERMUTATION
     "TYPE=[f16vec4|vec4]"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_cc_binary(

--- a/benchmarks/matmul/CMakeLists.txt
+++ b/benchmarks/matmul/CMakeLists.txt
@@ -28,6 +28,8 @@ uvkc_glsl_shader_permutation(
     "TEXTURE=[1|0]"
     "WG_X=32"
     "WG_Y=2"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_glsl_shader_permutation(
@@ -41,6 +43,8 @@ uvkc_glsl_shader_permutation(
     "TILE_K=[4|8]"
     "WG_X=32"
     "WG_Y=2"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_glsl_shader_permutation(
@@ -54,6 +58,8 @@ uvkc_glsl_shader_permutation(
     "TILE_K=[4|8]"
     "WG_X=32"
     "WG_Y=2"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_glsl_shader_permutation(
@@ -67,6 +73,8 @@ uvkc_glsl_shader_permutation(
     "TILE_K=[4|8]"
     "WG_X=32"
     "WG_Y=2"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_glsl_shader_permutation(
@@ -80,6 +88,8 @@ uvkc_glsl_shader_permutation(
     "TILE_K=[4|8]"
     "WG_X=32"
     "WG_Y=2"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_cc_binary(
@@ -116,6 +126,8 @@ uvkc_glsl_shader_permutation(
     "TEXTURE=[1|0]"
     "WG_X=8"
     "WG_Y=2"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_glsl_shader_permutation(
@@ -129,6 +141,8 @@ uvkc_glsl_shader_permutation(
     "TILE_K=[4|8]"
     "WG_X=16"
     "WG_Y=1"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_glsl_shader_permutation(
@@ -142,6 +156,8 @@ uvkc_glsl_shader_permutation(
     "TILE_K=[4|8]"
     "WG_X=16"
     "WG_Y=1"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_glsl_shader_permutation(
@@ -155,6 +171,8 @@ uvkc_glsl_shader_permutation(
     "TILE_K=[4|8]"
     "WG_X=16"
     "WG_Y=1"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_glsl_shader_permutation(
@@ -168,6 +186,8 @@ uvkc_glsl_shader_permutation(
     "TILE_K=[4|8]"
     "WG_X=16"
     "WG_Y=1"
+  GLSLC_ARGS
+    "--target-env=vulkan1.1"
 )
 
 uvkc_cc_binary(


### PR DESCRIPTION
All the benchmarks use this expect compute and matmul, which fail to compile, complamning that SPIR-V 1.3 is required. If we dont' specity the target we use vulkan-1.0 which default to SPIR-V 1.0.

     glslc -h
     ...
	  --target-env=<environment>
			    Set the target client environment, and the semantics
			    of warnings and errors.  An optional suffix can specify
			    the client version.  Values are:
				vulkan1.0       # The default
				vulkan1.1
				vulkan1.2
				vulkan1.3
				vulkan1.4
				vulkan          # Same as vulkan1.0
				opengl4.5
				opengl          # Same as opengl4.5
	  --target-spv=<spirv-version>
			    Set the SPIR-V version to be used for the generated SPIR-V
			    module.  The default is the highest version of SPIR-V
			    required to be supported for the target environment.
			    For example, default for vulkan1.0 is spv1.0, and
			    the default for vulkan1.1 is spv1.3,
			    the default for vulkan1.2 is spv1.5,
			    the default for vulkan1.3 is spv1.6,
			    the default for vulkan1.4 is spv1.6.
			    Values are:
				spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5, spv1.6